### PR TITLE
Fix missing 'each sentence in a new line' in chapter 10

### DIFF
--- a/docs_src/gitbuch_10.adoc
+++ b/docs_src/gitbuch_10.adoc
@@ -7,58 +7,90 @@
 include::gitbuch_footnotes.adoc[tag=Chapter_10]
 
 ////
-Da Sie Git-Kommandos zumeist auf der Shell ausführen, sollten Sie diese um Funktionalität erweitern, um mit Git zu interagieren. Gerade für Git-Anfänger ist ein solches Zusammenspiel zwischen Shell und Git sehr hilfreich, um nicht den Überblick zu verlieren.
+Da Sie Git-Kommandos zumeist auf der Shell ausführen, sollten Sie diese um Funktionalität erweitern, um mit Git zu interagieren.
+Gerade für Git-Anfänger ist ein solches Zusammenspiel zwischen Shell und Git sehr hilfreich, um nicht den Überblick zu verlieren.
 ////
 
-Since you usually run Git commands on the shell, you should add functionality to them to interact with Git. Especially for Git beginners, such interaction between shell and Git is very helpful to keep track of things.
+Since you usually run Git commands on the shell, you should add functionality to them to interact with Git.
+Especially for Git beginners, such interaction between shell and Git is very helpful to keep track of things.
 
 ////
 In zwei Bereichen kann die Shell Ihnen besonders helfen:
 
-* Anzeige wichtiger Informationen zu einem Repository im _Prompt_ (Eingabeaufforderung). So müssen Sie nicht allzu häufig `git status` und Konsorten aufrufen.
+* Anzeige wichtiger Informationen zu einem Repository im _Prompt_ (Eingabeaufforderung).
+* So müssen Sie nicht allzu häufig `git status` und Konsorten aufrufen.
 
 * Eine maßgeschneiderte _Completion_ (automatische Vervollständigung) hilft, Git-Kommandos direkt richtig einzugeben, auch wenn die genaue Syntax nicht bekannt ist.
 ////
 
 There are two areas in which the shell can help you:
 
-* Display important information about a repository at the _prompt_. This way you don't have to call `git status` and consorts too often.
+* Display important information about a repository at the _prompt_.
+* This way you don't have to call `git status` and consorts too often.
 
 * A custom _completion_ helps you to enter git commands correctly, even if you don't know the exact syntax.
 
 ////
-Ein gutes Prompt sollte zusätzlich zum aktuellen Branch den Zustand des Working Tree signalisieren. Gibt es Veränderungen, die noch nicht gespeichert sind? Befinden sich schon Veränderungen im Index?
+Ein gutes Prompt sollte zusätzlich zum aktuellen Branch den Zustand des Working Tree signalisieren.
+Gibt es Veränderungen, die noch nicht gespeichert sind?
+Befinden sich schon Veränderungen im Index?
 ////
 
-A good prompt should signal the state of the working tree in addition to the current branch. Are there any changes that are not yet saved? Are there already changes in the index?
+A good prompt should signal the state of the working tree in addition to the current branch.
+Are there any changes that are not yet saved?
+Are there already changes in the index?
 
 ////
-Eine gute Completion sollte etwa bei der Eingabe von `git checkout` und dem anschließenden Drücken der Tab-Taste nur Branches aus dem Repository zur Vervollständigung anbieten. Wenn Sie aber `git checkout --` eingeben, sollten nur Dateien vervollständigt werden. Das spart Zeit und schützt vor Tippfehlern. Auch andere Vervollständigungen sind sinnvoll, z.B. die vorhandenen Remotes bei `git push` und `git pull`.
+Eine gute Completion sollte etwa bei der Eingabe von `git checkout` und dem anschließenden Drücken der Tab-Taste nur Branches aus dem Repository zur Vervollständigung anbieten.
+Wenn Sie aber `git checkout --` eingeben, sollten nur Dateien vervollständigt werden.
+Das spart Zeit und schützt vor Tippfehlern.
+Auch andere Vervollständigungen sind sinnvoll, z.B. die vorhandenen Remotes bei `git push` und `git pull`.
 ////
 
-A good completion should, for example, when entering `git checkout` and then pressing the Tab key, only offer branches from the repository for completion. But if you type `git checkout --` only files should be completed. This saves time and protects against typos. Other completions are also useful, such as the existing remotes for `git push` and `git pull`.
+A good completion should, for example, when entering `git checkout` and then pressing the Tab key, only offer branches from the repository for completion.
+But if you type `git checkout --` only files should be completed.
+This saves time and protects against typos.
+Other completions are also useful, such as the existing remotes for `git push` and `git pull`.
 
 ////
-In diesem Kapitel stellen wir grundlegende Rezepte für zwei beliebte Shells vor: die _Bash_ und die _Z-Shell_. Anleitungen für andere interaktive Shells finden Sie ggf. im Internet.
+In diesem Kapitel stellen wir grundlegende Rezepte für zwei beliebte Shells vor: die _Bash_ und die _Z-Shell_.
+Anleitungen für andere interaktive Shells finden Sie ggf. im Internet.
 ////
 
-In this chapter we will introduce basic recipes for two popular shells: the _Bash_ and the _Z-Shell_. Instructions for other interactive shells can be found on the Internet.
+In this chapter we will introduce basic recipes for two popular shells: the _Bash_ and the _Z-Shell_.
+Instructions for other interactive shells can be found on the Internet.
 
 ////
-Das Thema Shell-Integration ist sehr umfangreich, daher stellen die hier vorgestellten Anleitungen lediglich Anhaltspunkte und Ideen dar und erheben keinen Anspruch auf Vollständigkeit.  Es kommt erschwerend hinzu, dass die Git-Community die Benutzerschnittstelle -- also die vorhandenen Subkommandos und deren Optionen -- sehr schnell weiterentwickelt. Bitte wundern Sie sich daher nicht, wenn die Completion teilweise "`hinterherhinkt`" und brandneue Subkommandos und Optionen (noch) nicht verfügbar sind.
+Das Thema Shell-Integration ist sehr umfangreich, daher stellen die hier vorgestellten Anleitungen lediglich Anhaltspunkte und Ideen dar und erheben keinen Anspruch auf Vollständigkeit.
+Es kommt erschwerend hinzu, dass die Git-Community die Benutzerschnittstelle -- also die vorhandenen Subkommandos und deren Optionen -- sehr schnell weiterentwickelt.
+Bitte wundern Sie sich daher nicht, wenn die Completion teilweise "`hinterherhinkt`" und brandneue Subkommandos und Optionen (noch) nicht verfügbar sind.
 ////
 
-The topic of shell integration is very extensive, so the tutorials presented here are only guidelines and ideas and do not claim to be complete. To make matters worse, the git community is developing the user interface - i.e. the existing subcommands and their options - very quickly. So please don't be surprised if the completion is "`lagging behind`" and brand new subcommands and options are not (yet) available.
+The topic of shell integration is very extensive, so the tutorials presented here are only guidelines and ideas and do not claim to be complete.
+To make matters worse, the git community is developing the user interface - i.e. the existing subcommands and their options - very quickly.
+So please don't be surprised if the completion is "`lagging behind`" and brand new subcommands and options are not (yet) available.
 
 [[sec.bash-integration]]
 == Git and the Bash
 // == Git und die Bash
 
 ////
-Sowohl die Funktionalität für die Completion als auch die Status-Kommandos für das Prompt sind in einem Script namens `git-completion.bash` implementiert. Es wird zusammen mit den Quellen für Git verwaltet. Sie finden die Datei im Verzeichnis `contrib/completion` des Git-Projekts. Häufig wird die Completion auch schon von Ihrer Distribution bzw. dem Git-Installer für Ihr Betriebssystem bereitgestellt. Haben Sie bei Debian oder Ubuntu das Paket `git` installiert, sollte die Datei bereits unter `/usr/share/bash-completion/completions/git` vorliegen. In Gentoo installieren Sie die Datei über das USE-Flag `bash-completion` von `dev-vcs/git`. Der aktuelle Maintainer ist Shawn O. Pearce.
+Sowohl die Funktionalität für die Completion als auch die Status-Kommandos für das Prompt sind in einem Script namens `git-completion.bash` implementiert.
+Es wird zusammen mit den Quellen für Git verwaltet.
+Sie finden die Datei im Verzeichnis `contrib/completion` des Git-Projekts.
+Häufig wird die Completion auch schon von Ihrer Distribution bzw. dem Git-Installer für Ihr Betriebssystem bereitgestellt.
+Haben Sie bei Debian oder Ubuntu das Paket `git` installiert, sollte die Datei bereits unter `/usr/share/bash-completion/completions/git` vorliegen.
+In Gentoo installieren Sie die Datei über das USE-Flag `bash-completion` von `dev-vcs/git`.
+Der aktuelle Maintainer ist Shawn O. Pearce.
 ////
 
-Both the functionality for completion and the status commands for the prompt are implemented in a script called `git-completion.bash`. It is managed together with the sources for Git. You can find the file in the `contrib/completion` directory of the Git project. Often the completion is already provided by your distribution or the git installer for your operating system. If you have installed the `git` package in Debian or Ubuntu, the file should already be in `/usr/share/bash-completion/completions/git`. In Gentoo, you install the file via the USE flag `bash-completion` of `dev-vcs/git`. The current maintainer is Shawn O. Pearce.
+Both the functionality for completion and the status commands for the prompt are implemented in a script called `git-completion.bash`.
+It is managed together with the sources for Git.
+You can find the file in the `contrib/completion` directory of the Git project.
+Often the completion is already provided by your distribution or the git installer for your operating system.
+If you have installed the `git` package in Debian or Ubuntu, the file should already be in `/usr/share/bash-completion/completions/git`.
+In Gentoo, you install the file via the USE flag `bash-completion` of `dev-vcs/git`.
+The current maintainer is Shawn O. Pearce.
 
 [[sec.bash-completion]]
 === Completion
@@ -92,10 +124,14 @@ pull push
 --------
 +
 ////
-Anmerkung: Nur die _Porcelain_-Kommandos sowie Benutzeraliase sind verfügbar. Externe- und _Plumbing_-Kommandos sind nicht implementiert. Subkommandos, die selber über weitere Subkommandos verfügen, z.B.{empty}{nbsp}`git remote` oder `git stash`, werden ebenfalls vervollständigt:
+Anmerkung: Nur die _Porcelain_-Kommandos sowie Benutzeraliase sind verfügbar.
+Externe- und _Plumbing_-Kommandos sind nicht implementiert.
+Subkommandos, die selber über weitere Subkommandos verfügen, z.B.{empty}{nbsp}`git remote` oder `git stash`, werden ebenfalls vervollständigt:
 ////
 +
-Note: Only the _porcelain_ commands and user aliases are available. External and _plumbing_ commands are not implemented. Subcommands that have additional subcommands themselves, e.g.{empty}{nbsp}``git remote`` or `git stash`, are also completed:
+Note: Only the _porcelain_ commands and user aliases are available.
+External and _plumbing_ commands are not implemented.
+Subcommands that have additional subcommands themselves, e.g.{empty}{nbsp}``git remote`` or `git stash`, are also completed:
 +
 [subs="macros,quotes"]
 --------
@@ -119,9 +155,11 @@ refactor-cmd-line    refactor-profiling
 --------
 
 ////
-Konfigurierte Remotes:: Kommandos wie `git fetch` und `git remote` werden oft mit einem Remote als Argument aufgerufen. Auch hier hilft die Completion weiter:
+Konfigurierte Remotes:: Kommandos wie `git fetch` und `git remote` werden oft mit einem Remote als Argument aufgerufen.
+Auch hier hilft die Completion weiter:
 ////
-Configured Remotes:: Commands like `git fetch` and `git remote` are often called with a remote as argument. Completion helps here too:
+Configured Remotes:: Commands like `git fetch` and `git remote` are often called with a remote as argument.
+Completion helps here too:
 +
 [subs="macros,quotes"]
 --------
@@ -130,9 +168,11 @@ github        sourceforge
 --------
 
 ////
-Remote Branches und Tags:: Die Completion kann auch auf der Remote-Seite "`nachsehen`", welche Referenzen vorhanden sind. Das erfolgt zum Beispiel beim Kommando `git pull`, das eine Remote-Referenz bzw. eine Refspec erwartet:
+Remote Branches und Tags:: Die Completion kann auch auf der Remote-Seite "`nachsehen`", welche Referenzen vorhanden sind.
+Das erfolgt zum Beispiel beim Kommando `git pull`, das eine Remote-Referenz bzw. eine Refspec erwartet:
 ////
-Remote Branches and Tags:: The Completion can also "`check`" on the remote page to see which references are available. This is done for example with the command `git pull`, which expects a remote reference or a refspec:
+Remote Branches and Tags:: The Completion can also "`check`" on the remote page to see which references are available.
+This is done for example with the command `git pull`, which expects a remote reference or a refspec:
 +
 [subs="macros,quotes"]
 --------
@@ -142,14 +182,18 @@ v1.7.1.1     v1.7.1.3     v1.7.1-rc0   v1.7.1-rc2
 --------
 +
 ////
-Das funktioniert natürlich nur, wenn das Remote-Repository verfügbar ist. In den meisten Fällen ist eine Netzwerkverbindung sowie mindestens Lesezugriff notwendig.
+Das funktioniert natürlich nur, wenn das Remote-Repository verfügbar ist.
+In den meisten Fällen ist eine Netzwerkverbindung sowie mindestens Lesezugriff notwendig.
 ////
-Of course this only works if the remote repository is available. In most cases a network connection and at least read access is required.
+Of course this only works if the remote repository is available.
+In most cases a network connection and at least read access is required.
 
 ////
-Optionen:: Die meisten Subkommandos verfügen über diverse _Long Options_ wie z.B.{empty}{nbsp}`--bare`. Die Completion kennt diese in der Regel und vervollständigt sie entsprechend:
+Optionen:: Die meisten Subkommandos verfügen über diverse _Long Options_ wie z.B.{empty}{nbsp}`--bare`.
+Die Completion kennt diese in der Regel und vervollständigt sie entsprechend:
 ////
-Options:: Most subcommands have several _long options_ like{empty}{nbsp}``--bare``. The completion usually knows these and completes them accordingly:
+Options:: Most subcommands have several _long options_ like{empty}{nbsp}``--bare``.
+The completion usually knows these and completes them accordingly:
 +
 [subs="macros,quotes"]
 --------
@@ -163,9 +207,11 @@ _Short Options_, wie z.B.{empty}{nbsp}`-a`, werden nicht komplettiert.
 _Short options_, such as{empty}{nbsp}``-a``, are not completed.
 
 ////
-Dateien:: Für Git-Kommandos, die Dateinamen erwarten. Gute Beispiele sind `git add` sowie `git checkout`:
+Dateien:: Für Git-Kommandos, die Dateinamen erwarten.
+Gute Beispiele sind `git add` sowie `git checkout`:
 ////
-Files:: For Git commands that expect file names. Good examples are `git add` and `git checkout`:
+Files:: For Git commands that expect file names.
+Good examples are `git add` and `git checkout`:
 +
 [subs="macros,quotes"]
 --------
@@ -187,20 +233,30 @@ user.email        user.name         user.signingkey
 --------
 
 ////
-Wie bei der Bash-Completion üblich, wird die Eingabe automatisch vervollständigt, sobald sie eindeutig ist. Existiert nur der Branch `feature`, führt die Eingabe von `git checkout fe[TAB]` dazu, dass `fe` vervollständigt wird; der Befehl `git checkout feature` steht dann auf der Kommandozeile -- drücken Sie auf Enter, um den Befehl auszuführen. Nur wenn die Eingabe nicht eindeutig ist, zeigt die Bash die möglichen Vervollständigungen an.
+Wie bei der Bash-Completion üblich, wird die Eingabe automatisch vervollständigt, sobald sie eindeutig ist.
+Existiert nur der Branch `feature`, führt die Eingabe von `git checkout fe[TAB]` dazu, dass `fe` vervollständigt wird; der Befehl `git checkout feature` steht dann auf der Kommandozeile -- drücken Sie auf Enter, um den Befehl auszuführen.
+Nur wenn die Eingabe nicht eindeutig ist, zeigt die Bash die möglichen Vervollständigungen an.
 ////
 
-As usual with bash completion, the input is automatically completed when it is unique. If only the Branch `feature` exists, typing `git checkout fe[TAB]` will cause `fe` to be completed; the command `git checkout feature` will then appear on the command line - press Enter to execute the command. Only when the input is ambiguous does the bash display the possible completions.
+As usual with bash completion, the input is automatically completed when it is unique.
+If only the Branch `feature` exists, typing `git checkout fe[TAB]` will cause `fe` to be completed; the command `git checkout feature` will then appear on the command line - press Enter to execute the command.
+Only when the input is ambiguous does the bash display the possible completions.
 
 [[sec.bash-prompt]]
 === Prompt
 // === Prompt
 
 ////
-Neben der Completion gibt es ein weiteres Script, um Infos über das Git-Repository im Prompt anzuzeigen. Dafür müssen Sie die Datei `contrib/completion/git-prompt.sh` laden (ggf. ist diese auch von Ihrer Distribution installiert, z.B. unter `/usr/lib/git-core/git-sh-prompt`). Setzen Sie anschließend -- wie in folgendem Beispiel -- einen Aufruf der Funktion `__git_ps1` in die Variable `PS1` ein. Als Argument nimmt die Funktion einen sogenannten _Format-String-Ausdruck_ entgegen -- d.h. die Zeichenfolge `%s` wird durch Git-Infos ersetzt, alle anderen Zeichen werden übernommen.
+Neben der Completion gibt es ein weiteres Script, um Infos über das Git-Repository im Prompt anzuzeigen.
+Dafür müssen Sie die Datei `contrib/completion/git-prompt.sh` laden (ggf. ist diese auch von Ihrer Distribution installiert, z.B. unter `/usr/lib/git-core/git-sh-prompt`).
+Setzen Sie anschließend -- wie in folgendem Beispiel -- einen Aufruf der Funktion `__git_ps1` in die Variable `PS1` ein.
+Als Argument nimmt die Funktion einen sogenannten _Format-String-Ausdruck_ entgegen -- d.h. die Zeichenfolge `%s` wird durch Git-Infos ersetzt, alle anderen Zeichen werden übernommen.
 ////
 
-Beside the completion there is another script to display information about the git repository in the prompt. For this you have to load the file `contrib/completion/git-prompt.sh` (maybe it is also installed by your distribution, e.g. under `/usr/lib/git-core/git-sh-prompt`). Then, as in the following example, place a call to the `\__git_ps1` function in the `PS1` variable. The function takes a so-called _format string expression_ as argument - i.e. the string `%s` is replaced by git infos, all other characters are taken over.
+Beside the completion there is another script to display information about the git repository in the prompt.
+For this you have to load the file `contrib/completion/git-prompt.sh` (maybe it is also installed by your distribution, e.g. under `/usr/lib/git-core/git-sh-prompt`).
+Then, as in the following example, place a call to the `\__git_ps1` function in the `PS1` variable.
+The function takes a so-called _format string expression_ as argument - i.e. the string `%s` is replaced by git infos, all other characters are taken over.
 
 --------
 source /usr/lib/git-core/git-sh-prompt
@@ -272,16 +328,24 @@ esc@creche ~/git-working/git (git)-[master|REBASE-i] $
 --------
 
 ////
-Sie können die Anzeige auch erweitern, um sich den Zustand des Working Trees durch verschiedene Symbole anzeigen zu lassen. Sie müssen dazu folgende Umgebungsvariablen auf einen _Non-Empty_-Wert setzen, also z.B. auf `1`.
+Sie können die Anzeige auch erweitern, um sich den Zustand des Working Trees durch verschiedene Symbole anzeigen zu lassen.
+Sie müssen dazu folgende Umgebungsvariablen auf einen _Non-Empty_-Wert setzen, also z.B. auf `1`.
 ////
 
-You can also expand the display to show the status of the Working Trees using different icons. To do this, you must set the following environment variables to a _non-empty_ value, e.g. to 1.
+You can also expand the display to show the status of the Working Trees using different icons.
+To do this, you must set the following environment variables to a _non-empty_ value, e.g. to 1.
 
 ////
-`GIT_PS1_SHOWDIRTYSTATE`:: Bei Veränderungen, die noch nicht im Index sind (_unstaged_), wird ein Sternchen (`*`) angezeigt. Bei Veränderungen, die bereits im Index sind (_staged_), wird ein Plus (`+`) angezeigt. Die Anzeige erfordert, dass der Working Tree gelesen wird -- dadurch verlangsamt sich die Shell evtl. bei großen
-Repositories (Git muss jede Datei auf Modifikationen überprüfen). Sie können dieses Verhalten daher mit der Git-Variable `bash.showDirtyState` für einzelne Repositories deaktivieren:
+`GIT_PS1_SHOWDIRTYSTATE`:: Bei Veränderungen, die noch nicht im Index sind (_unstaged_), wird ein Sternchen (`*`) angezeigt.
+Bei Veränderungen, die bereits im Index sind (_staged_), wird ein Plus (`+`) angezeigt.
+Die Anzeige erfordert, dass der Working Tree gelesen wird -- dadurch verlangsamt sich die Shell evtl. bei großen
+Repositories (Git muss jede Datei auf Modifikationen überprüfen).
+Sie können dieses Verhalten daher mit der Git-Variable `bash.showDirtyState` für einzelne Repositories deaktivieren:
 ////
-`GIT_PS1_SHOWDIRTYSTATE`:: For changes that are not yet in the index (_unstaged_), an asterisk (`*`) is displayed. For changes that are already in the index (_staged_), a plus (`+`) is displayed. The display requires the working tree to be read - this may slow down the shell for large repositories (Git has to check every file for modifications). You can therefore disable this behavior for individual repositories with the Git variable `bash.showDirtyState`:
+`GIT_PS1_SHOWDIRTYSTATE`:: For changes that are not yet in the index (_unstaged_), an asterisk (`*`) is displayed.
+For changes that are already in the index (_staged_), a plus (`+`) is displayed.
+The display requires the working tree to be read - this may slow down the shell for large repositories (Git has to check every file for modifications).
+You can therefore disable this behavior for individual repositories with the Git variable `bash.showDirtyState`:
 +
 [subs="macros,quotes"]
 --------
@@ -323,20 +387,30 @@ esc@creche ~/git-working/git (git)-[master *+$%] $
 --------
 
 ////
-In neueren Git-Versionen verfügt das Script über ein neues Feature, das die Beziehung zum Upstream-Branch (`@{upstream}`) anzeigt.  Aktivieren Sie diese Funktion durch Setzen von `GIT_PS1_SHOWUPSTREAM` auf den Wert `git`.{fn134} Das Prompt signalisiert dann alle Zustände, die in <<sec.remote-branch-vv>> beschrieben sind: _up-to-date_ mit dem Gleichheitszeichen (`=`); _ahead_ mit dem Größer-als-Zeichen (`>`); _behind_ mit dem Kleiner-als-Zeichen (`<`); _diverged_ mit sowohl einem Größer-als-Zeichen und einem Kleiner-als-Zeichen (`><`). Zum Beispiel:
+In neueren Git-Versionen verfügt das Script über ein neues Feature, das die Beziehung zum Upstream-Branch (`@{upstream}`) anzeigt.
+Aktivieren Sie diese Funktion durch Setzen von `GIT_PS1_SHOWUPSTREAM` auf den Wert `git`.{fn134} Das Prompt signalisiert dann alle Zustände, die in <<sec.remote-branch-vv>> beschrieben sind: _up-to-date_ mit dem Gleichheitszeichen (`=`); _ahead_ mit dem Größer-als-Zeichen (`>`); _behind_ mit dem Kleiner-als-Zeichen (`<`); _diverged_ mit sowohl einem Größer-als-Zeichen und einem Kleiner-als-Zeichen (`><`).
+Zum Beispiel:
 ////
 
-In newer Git versions, the script has a new feature that shows the relationship to the upstream branch (`@{upstream}`). Enable this feature by setting `GIT_PS1_SHOWUPSTREAM` to the value `git`.{fn134} The prompt then signals all states described in Section 5.5.2, "Comparison with the Upstream": _up-to-date_ with the equal sign (`=`); _ahead_ with the greater-than sign (`>`); _behind_ with the less-than sign (`<`); _diverged_ with both a greater-than sign and a less-than sign (`><`). For example:
+In newer Git versions, the script has a new feature that shows the relationship to the upstream branch (`@{upstream}`).
+Enable this feature by setting `GIT_PS1_SHOWUPSTREAM` to the value `git`.{fn134} The prompt then signals all states described in Section 5.5.2, "Comparison with the Upstream": _up-to-date_ with the equal sign (`=`); _ahead_ with the greater-than sign (`>`); _behind_ with the less-than sign (`<`); _diverged_ with both a greater-than sign and a less-than sign (`><`).
+For example:
 
 --------
 esc@creche ~/git-working/git (git)-[master >] $
 --------
 
 ////
-Diese Funktion ist mit der Option `--count` des Plumbing-Kommandos `git rev-list` implementiert, die in alten Git-Versionen, etwa 1.7.1, noch nicht existiert. Haben Sie eine solche alte Git-Version, aber ein aktuelles Script und wollen diese Anzeige trotzdem verwenden, setzen Sie den Wert der Umgebungsvariablen auf `legacy` -- das Script verwendet dann eine alternative Implementation, die ohne die besagte Option auskommt. Wenn Sie außerdem noch wissen wollen, wie weit der Branch vorne bzw. zurück liegt, fügen Sie den Wert `verbose` hinzu. Das Prompt zeigt dann auch noch die Anzahl der unterschiedlichen Commits an:
+Diese Funktion ist mit der Option `--count` des Plumbing-Kommandos `git rev-list` implementiert, die in alten Git-Versionen, etwa 1.7.1, noch nicht existiert.
+Haben Sie eine solche alte Git-Version, aber ein aktuelles Script und wollen diese Anzeige trotzdem verwenden, setzen Sie den Wert der Umgebungsvariablen auf `legacy` -- das Script verwendet dann eine alternative Implementation, die ohne die besagte Option auskommt.
+Wenn Sie außerdem noch wissen wollen, wie weit der Branch vorne bzw. zurück liegt, fügen Sie den Wert `verbose` hinzu.
+Das Prompt zeigt dann auch noch die Anzahl der unterschiedlichen Commits an:
 ////
 
-This function is implemented with the `--count` option of the `git rev-list` plumbing command, which does not exist in old git versions, like 1.7.1. If you have such an old git version, but a current script and want to use this display anyway, set the value of the environment variable to `legacy` - the script will then use an alternative implementation that works without the said option. If you also want to know how far ahead or behind the branch is, add the value `verbose`. The prompt will also show the number of different commits:
+This function is implemented with the `--count` option of the `git rev-list` plumbing command, which does not exist in old git versions, like 1.7.1.
+If you have such an old git version, but a current script and want to use this display anyway, set the value of the environment variable to `legacy` - the script will then use an alternative implementation that works without the said option.
+If you also want to know how far ahead or behind the branch is, add the value `verbose`.
+The prompt will also show the number of different commits:
 
 --------
 esc@creche ~/git-working/git (git)-[master u+2] $
@@ -366,7 +440,8 @@ Both completion and prompt functions are always included with the Z-Shell.
 ========
 
 ////
-Die Z-Shell verfügt über ein sehr nützliches Feature, um Man-Pages aufzurufen: die `run-help` Funktion. Sie wird im Emacs-Modus standardmäßig mit _Esc+H_ aufgerufen und zeigt für das Kommando, das bereits auf der Kommandozeile steht, die Man-Page an:
+Die Z-Shell verfügt über ein sehr nützliches Feature, um Man-Pages aufzurufen: die `run-help` Funktion.
+Sie wird im Emacs-Modus standardmäßig mit _Esc+H_ aufgerufen und zeigt für das Kommando, das bereits auf der Kommandozeile steht, die Man-Page an:
 
 [subs="macros,quotes"]
 --------
@@ -375,7 +450,8 @@ $ *man[ESC]+[h]*
 --------
 ////
 
-The Z-Shell has a very useful feature to call man pages: the `run-help` function. It is called by default with `Esc+H` in Emacs mode and displays the man page for the command that is already on the command line:
+The Z-Shell has a very useful feature to call man pages: the `run-help` function.
+It is called by default with `Esc+H` in Emacs mode and displays the man page for the command that is already on the command line:
 
 [subs="macros,quotes"]
 --------
@@ -384,7 +460,8 @@ $ *man[ESC]+[h]*
 --------
 
 ////
-Da Git aber aus Subkommandos besteht und jedes Subkommando eine eigene Man-Page hat, funktioniert `run-help` nicht sonderlich gut -- es wird immer nur die Man-Page `git(1)` angezeigt. Hier schafft die mitgelieferte Funktion `run-help-git` Abhilfe:
+Da Git aber aus Subkommandos besteht und jedes Subkommando eine eigene Man-Page hat, funktioniert `run-help` nicht sonderlich gut -- es wird immer nur die Man-Page `git(1)` angezeigt.
+Hier schafft die mitgelieferte Funktion `run-help-git` Abhilfe:
 
 [subs="macros,quotes"]
 --------
@@ -398,7 +475,8 @@ $ *git rebase[ESC]+[h]*
 --------
 ////
 
-However, since Git consists of subcommands and each subcommand has its own man page, `run-help` does not work very well - only the man page `git(1)` is displayed. The included `run-help-git` function can help here:
+However, since Git consists of subcommands and each subcommand has its own man page, `run-help` does not work very well - only the man page `git(1)` is displayed.
+The included `run-help-git` function can help here:
 
 [subs="macros,quotes"]
 --------
@@ -435,9 +513,11 @@ Die Completion vervollständigt unter anderem:
 The completion completes among other things:
 
 ////
-Git-Subkommandos:: Subkommandos werden in der Z-Shell ebenfalls vervollständigt. Der Unterschied zur Bash ist, dass die Z-Shell zusätzlich zum eigentlichen Kommando noch eine Kurzbeschreibung anzeigt:
+Git-Subkommandos:: Subkommandos werden in der Z-Shell ebenfalls vervollständigt.
+Der Unterschied zur Bash ist, dass die Z-Shell zusätzlich zum eigentlichen Kommando noch eine Kurzbeschreibung anzeigt:
 ////
-Git subcommands:: Subcommands are also completed in the Z-Shell. The difference to Bash is that the Z-Shell displays a short description in addition to the actual command:
+Git subcommands:: Subcommands are also completed in the Z-Shell.
+The difference to Bash is that the Z-Shell displays a short description in addition to the actual command:
 +
 [subs="macros,quotes"]
 --------
@@ -481,15 +561,21 @@ Lokale Branches und Tags:: Die Z-Shell vervollständigt ebenfalls lokale Branche
 Local Branches and Tags:: The Z-Shell also completes local branches and tags - no difference to Bash.
 
 ////
-Konfigurierte Remotes:: Konfigurierte Remotes sind der Z-Shell bekannt. Für Subkommandos, bei denen nur ein konfiguriertes Remote in Frage kommt, z.B.{empty}{nbsp}`git remote show`, werden auch nur konfigurierte Remotes angezeigt. Sollte dies nicht eindeutig sein, wie z.B. bei `git pull`, dann greifen zusätzliche Mechanismen der Z-Shell und es wird meist eine lange Liste angezeigt, die sich unter anderem aus den Einträgen in den Dateien `.ssh/config` (die konfigurierten SSH-Hosts) und `.ssh/known_hosts` (Hosts, auf denen Sie sich schon mal eingeloggt haben) besteht.
+Konfigurierte Remotes:: Konfigurierte Remotes sind der Z-Shell bekannt.
+Für Subkommandos, bei denen nur ein konfiguriertes Remote in Frage kommt, z.B.{empty}{nbsp}`git remote show`, werden auch nur konfigurierte Remotes angezeigt.
+Sollte dies nicht eindeutig sein, wie z.B. bei `git pull`, dann greifen zusätzliche Mechanismen der Z-Shell und es wird meist eine lange Liste angezeigt, die sich unter anderem aus den Einträgen in den Dateien `.ssh/config` (die konfigurierten SSH-Hosts) und `.ssh/known_hosts` (Hosts, auf denen Sie sich schon mal eingeloggt haben) besteht.
 ////
 
-Configured Remotes:: Configured remotes are known to the Z-Shell. For subcommands where only a configured remote is possible, e.g.{empty}{nbsp}``git remote show``, only configured remotes are displayed. If this is not clear, e.g. `git pull`, additional mechanisms of the Z-Shell take effect and usually a long list is displayed, which consists of the entries in the files `.ssh/config` (the configured SSH hosts) and `.ssh/known_hosts` (hosts you have already logged in to).
+Configured Remotes:: Configured remotes are known to the Z-Shell.
+For subcommands where only a configured remote is possible, e.g.{empty}{nbsp}``git remote show``, only configured remotes are displayed.
+If this is not clear, e.g. `git pull`, additional mechanisms of the Z-Shell take effect and usually a long list is displayed, which consists of the entries in the files `.ssh/config` (the configured SSH hosts) and `.ssh/known_hosts` (hosts you have already logged in to).
 
 ////
-Optionen:: Im Gegensatz zur Bash kennt die Z-Shell sowohl lange als auch kurze Optionen und zeigt sie inklusive einer Kurzbeschreibung der Option. Hier ein Auszug:
+Optionen:: Im Gegensatz zur Bash kennt die Z-Shell sowohl lange als auch kurze Optionen und zeigt sie inklusive einer Kurzbeschreibung der Option.
+Hier ein Auszug:
 ////
-Options:: Unlike Bash, Z-Shell knows both long and short options and shows them including a short description of the option. Here is an excerpt:
+Options:: Unlike Bash, Z-Shell knows both long and short options and shows them including a short description of the option.
+Here is an excerpt:
 +
 [subs="macros,quotes"]
 --------
@@ -500,16 +586,21 @@ $ *git branch -[TAB]*
 --------
 
 ////
-Dateien:: Die Z-Shell ist ebenfalls in der Lage, Dateinamen zu vervollständigen -- sie stellt sich aber etwas schlauer an als die Bash. Zum Beispiel werden für `git add` und `git checkout` nur Dateien angeboten, die tatsächlich Veränderungen haben -- also Dateien, die entweder dem Index hinzugefügt oder zurückgesetzt werden
-können. Dateien, die nicht in Betracht kommen, werden auch nicht angeboten.
+Dateien:: Die Z-Shell ist ebenfalls in der Lage, Dateinamen zu vervollständigen -- sie stellt sich aber etwas schlauer an als die Bash.
+Zum Beispiel werden für `git add` und `git checkout` nur Dateien angeboten, die tatsächlich Veränderungen haben -- also Dateien, die entweder dem Index hinzugefügt oder zurückgesetzt werden können.
+Dateien, die nicht in Betracht kommen, werden auch nicht angeboten.
 ////
 
-Files:: The Z-Shell is also able to complete file names - but it is a bit smarter than Bash. For example, for `git add` and `git checkout`, only files that actually have changes are offered - files that can either be added to the index or reset. Files that do not qualify are not offered either.
+Files:: The Z-Shell is also able to complete file names - but it is a bit smarter than Bash.
+For example, for `git add` and `git checkout`, only files that actually have changes are offered - files that can either be added to the index or reset.
+Files that do not qualify are not offered either.
 
 ////
-Git-Konfigurationsoptionen:: Die Z-Shell-Completion für Git vervollständigt, wie die Bash auch, sämtliche Konfigurationsoptionen für Git. Der Unterschied ist, dass auch hier eine Kurzbeschreibung der Optionen mit angezeigt wird:
+Git-Konfigurationsoptionen:: Die Z-Shell-Completion für Git vervollständigt, wie die Bash auch, sämtliche Konfigurationsoptionen für Git.
+Der Unterschied ist, dass auch hier eine Kurzbeschreibung der Optionen mit angezeigt wird:
 ////
-Git configuration options:: Like Bash, the Z-Shell completion for Git completes all configuration options for Git. The difference is that it also includes a short description of the options:
+Git configuration options:: Like Bash, the Z-Shell completion for Git completes all configuration options for Git.
+The difference is that it also includes a short description of the options:
 +
 [subs="macros,quotes"]
 --------
@@ -520,10 +611,14 @@ signingkey   -- default GPG key to use when creating signed tags
 --------
 
 ////
-Ein großer Unterschied bei der Z-Shell ist die Art und Weise, wie vervollständigt wird. Die Z-Shell verwendet die sogenannte _Menu-Completion_. Das bedeutet, dass Ihnen die Z-Shell durch erneutes Drücken der Tab-Taste jeweils die nächste mögliche Vervollständigung anbietet.{fn135}
+Ein großer Unterschied bei der Z-Shell ist die Art und Weise, wie vervollständigt wird.
+Die Z-Shell verwendet die sogenannte _Menu-Completion_.
+Das bedeutet, dass Ihnen die Z-Shell durch erneutes Drücken der Tab-Taste jeweils die nächste mögliche Vervollständigung anbietet.{fn135}
 ////
 
-A big difference with the Z-Shell is the way it is completed. The Z-Shell uses the so-called _menu completion_. This means that the Z-Shell offers you the next possible completion by pressing the Tab key again.{fn135}
+A big difference with the Z-Shell is the way it is completed.
+The Z-Shell uses the so-called _menu completion_.
+This means that the Z-Shell offers you the next possible completion by pressing the Tab key again.{fn135}
 
 [subs="macros,quotes"]
 --------
@@ -536,11 +631,16 @@ $ git push
 --------
 
 ////
-Die Z-Shell ist (noch) nicht in der Lage, Referenzen auf der Remote-Seite zu vervollständigen -- dies steht jedoch auf der To-do-Liste. Die Z-Shell ist aber heute schon in der Lage, Dateien über eine SSH-Verbindung hinweg zu vervollständigen. Besonders nützlich ist dies im Zusammenhang mit Public-Key-Authentifizierung und
-vorkonfigurierten SSH-Hosts.  Angenommen, Sie haben folgenden Host in `.ssh/config` konfiguriert:
+Die Z-Shell ist (noch) nicht in der Lage, Referenzen auf der Remote-Seite zu vervollständigen -- dies steht jedoch auf der To-do-Liste.
+Die Z-Shell ist aber heute schon in der Lage, Dateien über eine SSH-Verbindung hinweg zu vervollständigen.
+Besonders nützlich ist dies im Zusammenhang mit Public-Key-Authentifizierung und vorkonfigurierten SSH-Hosts.
+Angenommen, Sie haben folgenden Host in `.ssh/config` konfiguriert:
 ////
 
-The Z-Shell is not (yet) able to complete references on the remote side - but this is on the to-do list. But the Z-Shell is already able to complete files over an SSH connection. This is especially useful in connection with public key authentication and preconfigured SSH hosts. Assume you have configured the following host in `.ssh/config`:
+The Z-Shell is not (yet) able to complete references on the remote side - but this is on the to-do list.
+But the Z-Shell is already able to complete files over an SSH connection.
+This is especially useful in connection with public key authentication and preconfigured SSH hosts.
+Assume you have configured the following host in `.ssh/config`:
 
 --------
 Host example
@@ -549,10 +649,14 @@ Host example
 --------
 
 ////
-Auf dem Server in Ihrem Home-Verzeichnis befinden sich Ihre Projekte als Bare-Repositories: `projekt1.git` und `projekt2.git`. Außerdem haben Sie einen SSH-Schlüssel generiert und diesen in der Datei `.ssh/authorized_keys` auf dem Server abgelegt. Sie können nun die Vervollständigung über die SSH-Verbindung hinweg nutzen.
+Auf dem Server in Ihrem Home-Verzeichnis befinden sich Ihre Projekte als Bare-Repositories: `projekt1.git` und `projekt2.git`.
+Außerdem haben Sie einen SSH-Schlüssel generiert und diesen in der Datei `.ssh/authorized_keys` auf dem Server abgelegt.
+Sie können nun die Vervollständigung über die SSH-Verbindung hinweg nutzen.
 ////
 
-On the server in your home directory your projects are located as bare repositories: `project1.git` and `project2.git`. You also generated an SSH key and stored it in the `.ssh/authorized_keys` file on the server. You can now use completion across the SSH connection.
+On the server in your home directory your projects are located as bare repositories: `project1.git` and `project2.git`.
+You also generated an SSH key and stored it in the `.ssh/authorized_keys` file on the server.
+You can now use completion across the SSH connection.
 
 [subs="macros,quotes"]
 --------
@@ -571,16 +675,30 @@ This is made possible by the completion functions of the Z-shell for `ssh`.
 // === Prompt
 
 ////
-Die Z-Shell beinhaltet Funktionen, um das Prompt mit Git-Infos zu versehen. Die Funktionalität ist Teil des umfangreichen `vcs_info`-Systems, das neben Git circa ein Dutzend anderer Programme zur Versionsverwaltung kennt, inklusive Subversion, CVS und Mercurial. Die ausführliche Dokumentation finden Sie in der Man-Page `zshcontrib(1)`, im Abschnitt "`Gathering Information From Version Control Systems`". Hier stellen wir nur die für Git relevanten Einstellungen und Anpassungsmöglichkeiten vor.
+Die Z-Shell beinhaltet Funktionen, um das Prompt mit Git-Infos zu versehen.
+Die Funktionalität ist Teil des umfangreichen `vcs_info`-Systems, das neben Git circa ein Dutzend anderer Programme zur Versionsverwaltung kennt, inklusive Subversion, CVS und Mercurial.
+Die ausführliche Dokumentation finden Sie in der Man-Page `zshcontrib(1)`, im Abschnitt "`Gathering Information From Version Control Systems`".
+Hier stellen wir nur die für Git relevanten Einstellungen und Anpassungsmöglichkeiten vor.
 ////
 
-The Z-Shell contains functions to add git info to the prompt. The functionality is part of the extensive `vcs_info` system, which knows about a dozen other version control programs besides Git, including Subversion, CVS and Mercurial. Detailed documentation can be found in the `zshcontrib(1)` man page, in the "`Gathering Information From Version Control Systems`" section. Here we will only present the settings and customization options relevant to Git.
+The Z-Shell contains functions to add git info to the prompt.
+The functionality is part of the extensive `vcs_info` system, which knows about a dozen other version control programs besides Git, including Subversion, CVS and Mercurial.
+Detailed documentation can be found in the `zshcontrib(1)` man page, in the "`Gathering Information From Version Control Systems`" section.
+Here we will only present the settings and customization options relevant to Git.
 
 ////
-Zunächst müssen Sie `vcs_info` laden und das Prompt so anpassen, dass Git-Infos angezeigt werden. Hierbei ist wichtig, dass die Z-Shell-Option `prompt_subst` gesetzt ist; sie sorgt dafür, dass Variablen im Prompt auch tatsächlich ersetzt werden, außerdem müssen Sie die Funktion `vcs_info` in der Funktion `precmd` aufrufen. `precmd` wird direkt vor der Anzeige des Prompts aufgerufen. Der Aufruf `vcs_info` darin sorgt dafür, dass die Git-Infos auch tatsächlich in der Variable `${vcs_info_msg_0_}` gespeichert werden. Fügen Sie Ihrer `.zshrc` folgende Zeilen hinzu, falls sie noch nicht enthalten sind:
+Zunächst müssen Sie `vcs_info` laden und das Prompt so anpassen, dass Git-Infos angezeigt werden.
+Hierbei ist wichtig, dass die Z-Shell-Option `prompt_subst` gesetzt ist; sie sorgt dafür, dass Variablen im Prompt auch tatsächlich ersetzt werden, außerdem müssen Sie die Funktion `vcs_info` in der Funktion `precmd` aufrufen.
+`precmd` wird direkt vor der Anzeige des Prompts aufgerufen.
+Der Aufruf `vcs_info` darin sorgt dafür, dass die Git-Infos auch tatsächlich in der Variable `${vcs_info_msg_0_}` gespeichert werden.
+Fügen Sie Ihrer `.zshrc` folgende Zeilen hinzu, falls sie noch nicht enthalten sind:
 ////
 
-First, you need to load `vcs_info` and adjust the prompt to display Git info. It's important that the Z-Shell option `prompt_subst` is set; it ensures that variables in the prompt are actually replaced, and you must call `vcs_info` in the `precmd` function. `precmd` is called just before the prompt is displayed. The call `vcs_info` in it makes sure that the git info is actually stored in the variable `${vcs_info_msg_0_}`. Add the following lines to your `.zshrc` if they are not already included:
+First, you need to load `vcs_info` and adjust the prompt to display Git info.
+It's important that the Z-Shell option `prompt_subst` is set; it ensures that variables in the prompt are actually replaced, and you must call `vcs_info` in the `precmd` function.
+`precmd` is called just before the prompt is displayed.
+The call `vcs_info` in it makes sure that the git info is actually stored in the variable `${vcs_info_msg_0_}`.
+Add the following lines to your `.zshrc` if they are not already included:
 
 ////
 --------
@@ -607,10 +725,16 @@ PS1=_%n@%m %~${vcs_info_msg_0_} $ _
 --------
 
 ////
-Das Prompt setzt sich wie folgt zusammen: `%n` ist der Benutzername, `%m` ist der Rechnername, `%~` das aktuelle Arbeitsverzeichnis und die Variable `${vcs_info_msg_0_}` enthält die Git-Infos. Wichtig ist dabei, dass das Prompt mit einfachen Anführungszeichen (_single quotes_) angegeben wird. Dadurch wird die _Zeichenfolge_{empty}{nbsp}`${vcs_info_msg_0_}` und nicht der Wert der Variablen abgespeichert. Erst bei Anzeige des Prompt wird der Wert der Variablen -- also die Git-Infos -- substituiert.
+Das Prompt setzt sich wie folgt zusammen: `%n` ist der Benutzername, `%m` ist der Rechnername, `%~` das aktuelle Arbeitsverzeichnis und die Variable `${vcs_info_msg_0_}` enthält die Git-Infos.
+Wichtig ist dabei, dass das Prompt mit einfachen Anführungszeichen (_single quotes_) angegeben wird.
+Dadurch wird die _Zeichenfolge_{empty}{nbsp}`${vcs_info_msg_0_}` und nicht der Wert der Variablen abgespeichert.
+Erst bei Anzeige des Prompt wird der Wert der Variablen -- also die Git-Infos -- substituiert.
 ////
 
-The prompt is composed as follows: `%n` is the username, `%m` is the hostname, `%~` is the current working directory, and the variable `${vcs_info_msg_0_}` contains the git info. It is important that the prompt is specified with single quotes. This saves the _string_{empty}{nbsp}``${vcs_info_msg_0_}`` and not the value of the variable. Only when the prompt is displayed is the value of the variable - i.e. the git info - substituted.
+The prompt is composed as follows: `%n` is the username, `%m` is the hostname, `%~` is the current working directory, and the variable `${vcs_info_msg_0_}` contains the git info.
+It is important that the prompt is specified with single quotes.
+This saves the _string_{empty}{nbsp}``${vcs_info_msg_0_}`` and not the value of the variable.
+Only when the prompt is displayed is the value of the variable - i.e. the git info - substituted.
 
 ////
 Die o.g.  Einstellung für `PS1` sieht so aus:
@@ -660,10 +784,12 @@ esc@creche ~/git-working/git (git)-[e760924...] $
 --------
 
 ////
-Die Z-Shell kann, wie die Bash auch, Zustände des Working Trees anzeigen. Schalten Sie dies mit folgender Zeile an:
+Die Z-Shell kann, wie die Bash auch, Zustände des Working Trees anzeigen.
+Schalten Sie dies mit folgender Zeile an:
 ////
 
-The Z-Shell, like the Bash, can display states of the working tree. Switch this on with the following line:
+The Z-Shell, like the Bash, can display states of the working tree.
+Switch this on with the following line:
 
 --------
 zstyle _:vcs_info:git*:*_ check-for-changes true
@@ -680,10 +806,12 @@ esc@creche ~/git-working/git (git)-[master]US- $
 --------
 
 ////
-Ein großer Vorteil von `vcs_info` ist, dass es sich sehr leicht anpassen lässt. Gefallen Ihnen etwa die Buchstaben `U` und `S` nicht, können Sie sie durch andere Zeichen z.B.{empty}{nbsp}`*` und `+` ersetzen:
+Ein großer Vorteil von `vcs_info` ist, dass es sich sehr leicht anpassen lässt.
+Gefallen Ihnen etwa die Buchstaben `U` und `S` nicht, können Sie sie durch andere Zeichen z.B.{empty}{nbsp}`*` und `+` ersetzen:
 ////
 
-A big advantage of `vcs_info` is that it can be adapted very easily. For example, if you do not like the letters `U` and `S`, you can replace them with other characters, e.g.{empty}{nbsp}``*`` and `+`:
+A big advantage of `vcs_info` is that it can be adapted very easily.
+For example, if you do not like the letters `U` and `S`, you can replace them with other characters, e.g.{empty}{nbsp}``*`` and `+`:
 
 --------
 zstyle _:vcs_info:git*:*_ unstagedstr _*_
@@ -711,10 +839,14 @@ zstyle _:vcs_info:*_ disable-patterns "/home/esc/git-working/linux-2.6(|/*)"
 --------
 
 ////
-Vielleicht möchten Sie nun noch die Reihenfolge der Zeichen ändern. In dem Fall müssen Sie zwei Format-String Ausdrücke anpassen: `formats` und `actionformats`. Der erste ist das Standardformat, der zweite das Format, wenn Sie sich mitten in einem Merge-Vorgang, Rebase oder ähnlichem befinden:
+Vielleicht möchten Sie nun noch die Reihenfolge der Zeichen ändern.
+In dem Fall müssen Sie zwei Format-String Ausdrücke anpassen: `formats` und `actionformats`.
+Der erste ist das Standardformat, der zweite das Format, wenn Sie sich mitten in einem Merge-Vorgang, Rebase oder ähnlichem befinden:
 ////
 
-Maybe you want to change the order of the characters. In this case you need to adjust two format string expressions: `formats` and `actionformats`. The first is the default format, the second is the format when you are in the middle of a merge, rebase or similar process:
+Maybe you want to change the order of the characters.
+In this case you need to adjust two format string expressions: `formats` and `actionformats`.
+The first is the default format, the second is the format when you are in the middle of a merge, rebase or similar process:
 
 --------
 zstyle _:vcs_info:git*:*_ formats " (%s)-[%b%u%c]"
@@ -737,7 +869,8 @@ Eine Auswahl der wichtigsten Zeichen finden Sie in der folgenden Tabelle.  Eine 
 Mit der o.g. Einstellung sieht das Prompt dann so aus:
 ////
 
-A selection of the most important characters can be found in the following table. For a detailed list, please refer to the above mentioned man page.
+A selection of the most important characters can be found in the following table.
+For a detailed list, please refer to the above mentioned man page.
 
 `%s`:: version management system, in our case always `git`
 
@@ -756,16 +889,32 @@ esc@creche ~/git-working/git (git)-[master*+] $
 --------
 
 ////
-Leider kann `vcs_info` standardmäßig die Existenz unbekannter Dateien und angelegter Stashes nicht signalisieren. Das System unterstützt aber ab Z-Shell Version 4.3.11 sogenannte _Hooks_ -- Erweiterungen, die zusätzliche Information in das Prompt einschleusen. Wir werden nun zwei solcher Hooks vorstellen, die die beiden genannten, fehlenden Features implementieren.
+Leider kann `vcs_info` standardmäßig die Existenz unbekannter Dateien und angelegter Stashes nicht signalisieren.
+Das System unterstützt aber ab Z-Shell Version 4.3.11 sogenannte _Hooks_ -- Erweiterungen, die zusätzliche Information in das Prompt einschleusen.
+Wir werden nun zwei solcher Hooks vorstellen, die die beiden genannten, fehlenden Features implementieren.
 ////
 
-Unfortunately `vcs_info` cannot signal the existence of unknown files and created stashes by default. But since Z-Shell version 4.3.11 the system supports so called _hooks_ -- extensions, which inject additional information into the prompt. We will now introduce two such hooks, which implement the two missing features mentioned above.
+Unfortunately `vcs_info` cannot signal the existence of unknown files and created stashes by default.
+But since Z-Shell version 4.3.11 the system supports so called _hooks_ -- extensions, which inject additional information into the prompt.
+We will now introduce two such hooks, which implement the two missing features mentioned above.
 
 ////
-Die Hooks für `vcs_info` werden als Shell-Funktionen geschrieben. Beachten Sie, dass der Funktionsname das Präfix `+vi-` hat, um mögliche Kollisionen zu vermeiden. Damit ein Hook auch wirklich funktioniert, muss er einen Wert im assoziativen Array `hook_com` verändern. In beiden Beispielen verändern wir den Wert des Eintrags `staged`, indem wir zusätzliche Zeichen anhängen, um bestimmte Zustände zu markieren. Wir verwenden das Prozent-Zeichen (`%`), um unbekannte Dateien zu signalisieren, und das Dollar-Zeichen (`$`) für angelegte Stashes. Das Prozentzeichen muss zweimal angegeben werden, damit die Z-Shell es nicht fälschlich als Formatierung wertet. Bei den Hooks greifen wir auf diverse Plumbing-Kommandos zurück (siehe <<sec.scripting>>).
+Die Hooks für `vcs_info` werden als Shell-Funktionen geschrieben.
+Beachten Sie, dass der Funktionsname das Präfix `+vi-` hat, um mögliche Kollisionen zu vermeiden.
+Damit ein Hook auch wirklich funktioniert, muss er einen Wert im assoziativen Array `hook_com` verändern.
+In beiden Beispielen verändern wir den Wert des Eintrags `staged`, indem wir zusätzliche Zeichen anhängen, um bestimmte Zustände zu markieren.
+Wir verwenden das Prozent-Zeichen (`%`), um unbekannte Dateien zu signalisieren, und das Dollar-Zeichen (`$`) für angelegte Stashes.
+Das Prozentzeichen muss zweimal angegeben werden, damit die Z-Shell es nicht fälschlich als Formatierung wertet.
+Bei den Hooks greifen wir auf diverse Plumbing-Kommandos zurück (siehe <<sec.scripting>>).
 ////
 
-The hooks for `vcs_info` are written as shell functions. Note that the function name has the prefix `+vi-` to avoid possible collisions. For a hook to really work it has to change a value in the associative array `hook_com`. In both examples we change the value of the entry `staged` by appending additional characters to mark certain states. We use the percent sign (`%`) to indicate unknown files and the dollar sign (`$`) for created stashes. The percent sign must be specified twice to prevent the Z-Shell from mistakenly interpreting it as formatting. For the hooks we use various plumbing commands (see <<sec.scripting>>).
+The hooks for `vcs_info` are written as shell functions.
+Note that the function name has the prefix `+vi-` to avoid possible collisions.
+For a hook to really work it has to change a value in the associative array `hook_com`.
+In both examples we change the value of the entry `staged` by appending additional characters to mark certain states.
+We use the percent sign (`%`) to indicate unknown files and the dollar sign (`$`) for created stashes.
+The percent sign must be specified twice to prevent the Z-Shell from mistakenly interpreting it as formatting.
+For the hooks we use various plumbing commands (see <<sec.scripting>>).
 
 --------
 +vi-untracked(){
@@ -802,16 +951,22 @@ esc@creche ~/git-working/git (git)-[master*+$%] $
 --------
 
 ////
-Mit solchen Hooks ist es möglich, das Prompt nach Belieben zu erweitern. Zum Beispiel zeigt `vcs_info` standardmäßig nicht an, ob Sie sich innerhalb des `$GIT_DIR` oder aber in einem Bare-Repository befinden. Mit einem entsprechenden Hook bauen Sie diese Signale in das Prompt ein.
+Mit solchen Hooks ist es möglich, das Prompt nach Belieben zu erweitern.
+Zum Beispiel zeigt `vcs_info` standardmäßig nicht an, ob Sie sich innerhalb des `$GIT_DIR` oder aber in einem Bare-Repository befinden.
+Mit einem entsprechenden Hook bauen Sie diese Signale in das Prompt ein.
 ////
 
-With such hooks it is possible to extend the prompt as desired. For example, `vcs_info` does not show by default whether you are inside the `$GIT_DIR` or in a bare repository. With an appropriate hook you can include these signals in the prompt.
+With such hooks it is possible to extend the prompt as desired.
+For example, `vcs_info` does not show by default whether you are inside the `$GIT_DIR` or in a bare repository.
+With an appropriate hook you can include these signals in the prompt.
 
 ////
-Weitere Beispiele finden sich in der Datei `Misc/vcs_info-examples` des Z-Shell Repositorys, unter anderem auch ein Hook, der die Beziehung zum Upstream-Branch anzeigt (Abschnitt "`Compare local changes to remote changes`"). Eine minimale Konfiguration für die Z-Shell entsprechend den Beispielen in diesem Abschnitt finden Sie in der Scriptsammlung für dieses Buch.{fn137}
+Weitere Beispiele finden sich in der Datei `Misc/vcs_info-examples` des Z-Shell Repositorys, unter anderem auch ein Hook, der die Beziehung zum Upstream-Branch anzeigt (Abschnitt "`Compare local changes to remote changes`").
+Eine minimale Konfiguration für die Z-Shell entsprechend den Beispielen in diesem Abschnitt finden Sie in der Scriptsammlung für dieses Buch.{fn137}
 ////
 
-For more examples, see the `Misc/vcs_info-examples` file in the Z-Shell repository, including a hook that indicates the upstream branch relationship (section "`Compare local changes to remote changes`"). A minimal configuration for the Z-Shell according to the examples in this section can be found in the Scripts Collection for this book.{fn137}
+For more examples, see the `Misc/vcs_info-examples` file in the Z-Shell repository, including a hook that indicates the upstream branch relationship (section "`Compare local changes to remote changes`").
+A minimal configuration for the Z-Shell according to the examples in this section can be found in the Scripts Collection for this book.{fn137}
 
 //////////
 FIXME: Das muss hier alles ein dritter prüfen, der Ahnung von Shell hat, da kann soviel schief gehen.


### PR DESCRIPTION
I just had time to look at the git book again and unfortunately noticed that I forgot to put all sentences in a new line in chapter 10.